### PR TITLE
limit max lines to not hit textbox rendering limit

### DIFF
--- a/lib/typing.dart
+++ b/lib/typing.dart
@@ -176,7 +176,7 @@ class _TypingScreenState extends State<TypingScreen> {
                                       isDarkMode ? Colors.white : Colors.black,
                                 ),
                                 keyboardType: TextInputType.multiline,
-                                maxLines: null,
+                                maxLines: 4,
                               ),
                             ],
                           ),


### PR DESCRIPTION
Previously, when you type too many lines, this happens:

![error_too_many_lines](https://github.com/user-attachments/assets/42c0358d-df80-47d3-b7a7-763abd8276be)

Now when you limit the number of lines, it looks like this:

![limit_lines](https://github.com/user-attachments/assets/a3f9b36f-555a-4c9a-88dd-ffec13239878)
